### PR TITLE
Small fixes for common mods (fixes AOF3) @comp500

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -48,7 +48,7 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     private static final int SECTION_BLOCK_COUNT = SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH;
 
     // The radius of blocks around the origin chunk that should be copied.
-    private static final int NEIGHBOR_BLOCK_RADIUS = 1;
+    private static final int NEIGHBOR_BLOCK_RADIUS = 16;
 
     // The radius of chunks around the origin chunk that should be copied.
     private static final int NEIGHBOR_CHUNK_RADIUS = MathHelper.roundUpToMultiple(NEIGHBOR_BLOCK_RADIUS, 16) >> 4;

--- a/src/main/resources/sodium.mixins.json
+++ b/src/main/resources/sodium.mixins.json
@@ -47,5 +47,8 @@
     "features.texture_tracking.MixinSprite",
     "features.texture_tracking.MixinSpriteIdentifier",
     "features.world_ticking.MixinClientWorld"
-  ]
+  ],
+  "overwrites": {
+    "conformVisibility": true
+  }
 }


### PR DESCRIPTION
Set the conformVisibility option for Overwrites, which fixes GeckoLib 2.x
(GeckoLib 3.x fixes this issue properly, but some mods don't use it yet)
Changed the neighbor block radius in WorldSlice, as some mods need more
context in rendering (in particular LBG's snow layers and BetterEnd)