### PR TITLE
fix: Mark tripwire as translucent so that it is rendered back-to-front

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/render/chunk/passes/BlockRenderPass.java
@@ -8,7 +8,7 @@ public enum BlockRenderPass {
     CUTOUT(RenderLayer.getCutout(), false),
     CUTOUT_MIPPED(RenderLayer.getCutoutMipped(), false),
     TRANSLUCENT(RenderLayer.getTranslucent(), true),
-    TRIPWIRE(RenderLayer.getTripwire(), false);
+    TRIPWIRE(RenderLayer.getTripwire(), true);
 
     public static final BlockRenderPass[] VALUES = BlockRenderPass.values();
     public static final int COUNT = VALUES.length;


### PR DESCRIPTION
Both the TRANSLUCENT and TRIPWIRE render layers are rendered with translucency,
however Sodium treats the TRIPWIRE render layer as if it were opaque for the
purposes of determining whether chunks should be sorted back to front or front
to back.