### PR TITLE
fix: Increase WorldSlice neighbor radius to match vanilla

### DIFF
--- a/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
+++ b/src/main/java/me/jellysquid/mods/sodium/client/world/WorldSlice.java
@@ -48,7 +48,7 @@ public class WorldSlice extends ReusableObject implements BlockRenderView, Biome
     private static final int SECTION_BLOCK_COUNT = SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH * SECTION_BLOCK_LENGTH;
 
     // The radius of blocks around the origin chunk that should be copied.
-    private static final int NEIGHBOR_BLOCK_RADIUS = 1;
+    private static final int NEIGHBOR_BLOCK_RADIUS = 2;
 
     // The radius of chunks around the origin chunk that should be copied.
     private static final int NEIGHBOR_CHUNK_RADIUS = MathHelper.roundUpToMultiple(NEIGHBOR_BLOCK_RADIUS, 16) >> 4;


### PR DESCRIPTION
Several mods (primarily LambdaBetterGrass) require extra context in chunk rendering, that isn't provided by the 18x18x18 (5832 blocks) chunk section copy that Sodium makes. This change increases it to 20x20x20 (8000 blocks), which matches vanilla - so all mods should expect to have this radius of context for rendering. Unfortunately, as more blocks are being copied, this will impact chunk building performance very slightly, though much better than my original 48x48x48 change.

Other methods for increasing this radius without affecting performance (as this is very hot code) may be worth exploring, though it may not be worth the additional complexity.

The change has been tested in my Sodium fork, though the performance implications have not been directly measured.